### PR TITLE
chore(NA): removes demo env pipeline for 7.15 branch

### DIFF
--- a/pipelines/kibana-demo-env.tf
+++ b/pipelines/kibana-demo-env.tf
@@ -12,7 +12,7 @@ resource "buildkite_pipeline" "demo-env" {
   EOT
 
   default_branch       = "main"
-  branch_configuration = join(" ", local.current_dev_branches)
+  branch_configuration = join(" ", setsubtract(local.current_dev_branches, ["7.15"]))
 
   provider_settings {
     build_branches      = false


### PR DESCRIPTION
This PR removes the pipeline creation for demo environment on `7.15` which is erroring consistently https://buildkite.com/elastic/kibana-demo-environment/builds/186