### PR TITLE
Add c2-standard-60 instances to buildkite agents 

### DIFF
--- a/agents.json
+++ b/agents.json
@@ -27,6 +27,13 @@
         "exitAfterOneJob": false
       },
       {
+        "queue": "c2-60",
+        "name": "kb-c2-60",
+        "machineType": "c2-standard-60",
+        "localSsds": 2,
+        "maximumAgents": 20
+      },
+      {
         "queue": "c2-16",
         "name": "kb-c2-16",
         "machineType": "c2-standard-16",

--- a/agents.json
+++ b/agents.json
@@ -30,7 +30,7 @@
         "queue": "c2-60",
         "name": "kb-c2-60",
         "machineType": "c2-standard-60",
-        "localSsds": 2,
+        "localSsds": 8,
         "maximumAgents": 20
       },
       {


### PR DESCRIPTION
For the purpose of performance testing added c2-standard-60 machines which has 60 cores.