### PR TITLE
chore(NA): includes 7.17 on dev and hourly branches

### DIFF
--- a/pipelines/current-dev-branches.tf
+++ b/pipelines/current-dev-branches.tf
@@ -1,5 +1,5 @@
 locals {
-  current_dev_branches = ["main", "8.0", "7.16", "7.15"]
-  hourly_branches      = ["main", "8.0", "7.16"]
+  current_dev_branches = ["main", "8.0", "7.17", "7.16", "7.15"]
+  hourly_branches      = ["main", "8.0", "7.17"]
   daily_branches       = setsubtract(local.current_dev_branches, local.hourly_branches)
 }


### PR DESCRIPTION
This PR replaces the `7.16` branch with `7.17` on the hourly list and keep both on the list for the current dev ones.