### PR TITLE
Remove 8.0 from dev branches

### DIFF
--- a/pipelines/current-dev-branches.tf
+++ b/pipelines/current-dev-branches.tf
@@ -1,5 +1,5 @@
 locals {
-  current_dev_branches = ["main", "8.1", "8.0", "7.17"]
-  hourly_branches      = ["main", "8.1", "8.0", "7.17"]
+  current_dev_branches = ["main", "8.1", "7.17"]
+  hourly_branches      = ["main", "8.1", "7.17"]
   daily_branches       = setsubtract(local.current_dev_branches, local.hourly_branches)
 }


### PR DESCRIPTION
With the release of 8.1.0 we can remove 8.0 from our development
branches.