### PR TITLE
[kibana-es-forward] Test against 8.1.2

### DIFF
--- a/pipelines/kibana-es-forward.tf
+++ b/pipelines/kibana-es-forward.tf
@@ -44,7 +44,7 @@ resource "buildkite_pipeline" "es_forward_7_81" {
   steps       = <<-EOT
   env:
     SLACK_NOTIFICATIONS_ENABLED: 'true'
-    ES_SNAPSHOT_MANIFEST: 'https://storage.googleapis.com/kibana-ci-es-snapshots-daily/8.1.1/manifest-latest-verified.json'
+    ES_SNAPSHOT_MANIFEST: 'https://storage.googleapis.com/kibana-ci-es-snapshots-daily/8.1.2/manifest-latest-verified.json'
   steps:
     - label: ":pipeline: Pipeline upload"
       command: buildkite-agent pipeline upload .buildkite/pipelines/hourly.yml


### PR DESCRIPTION
8.1.1 went out today.  This bumps our forward compatibility testing job to 8.1.2