### PR TITLE
[agent] Install qemu-user-static

### DIFF
--- a/agents/ubuntu/ansible/roles/common/tasks/packages.yml
+++ b/agents/ubuntu/ansible/roles/common/tasks/packages.yml
@@ -110,6 +110,7 @@
       - vault
       - openjdk-16-jdk
       - openjdk-17-jdk
+      - qemu-user-static
       # For Chrome/FF below:
       - xvfb
       - gconf-service


### PR DESCRIPTION
This is used to add cross compilation support to docker.  This can be
validated by running `docker buildx inspect --bootstrap`:

```
Platforms: linux/amd64, linux/386, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/arm/v7, linux/arm/v6
```

Related - https://github.com/elastic/kibana/pull/128272