### PR TITLE
Vagrant/box cache 2

### DIFF
--- a/agents/ubuntu/ansible/roles/common/tasks/virt.yml
+++ b/agents/ubuntu/ansible/roles/common/tasks/virt.yml
@@ -2,6 +2,15 @@
   apt:
     deb: https://releases.hashicorp.com/vagrant/2.2.19/vagrant_2.2.19_x86_64.deb
 
+- name: Cache Vagrant boxes used for package testing
+  args:
+    executable: /bin/bash
+  shell: |
+    vagrant box add elastic/debian-9-x86_64
+    vagrant box add elastic/centos-7-x86_64
+    vagrant box add elastic/ubuntu-18.04-x86_64
+  when: not is_static
+
 - name: Install minikube
   apt:
     deb: https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb

--- a/agents/ubuntu/ansible/roles/common/tasks/virt.yml
+++ b/agents/ubuntu/ansible/roles/common/tasks/virt.yml
@@ -6,10 +6,11 @@
   args:
     executable: /bin/bash
   shell: |
-    vagrant box add elastic/debian-9-x86_64
-    vagrant box add elastic/centos-7-x86_64
-    vagrant box add elastic/ubuntu-18.04-x86_64
+    vagrant box add elastic/debian-9-x86_64 --no-tty
+    vagrant box add elastic/centos-7-x86_64 --no-tty
+    vagrant box add elastic/ubuntu-18.04-x86_64 --no-tty
   when: not is_static
+  ignore_errors: true
 
 - name: Install minikube
   apt:


### PR DESCRIPTION
Cache vagrant boxes used for package testing, attempt 2.  Adds --no-tty and ignore errors arguments.

I tried to test this locally and ran into:
```
 googlecompute.bk_dev: TASK [common : set_fact] *******************************************************
 googlecompute.bk_dev: fatal: [default]: FAILED! => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result"}
```

Assuming this is a vault issue, any workarounds?