### PR TITLE
Install vagrant boxes under buildkite-agent user

### DIFF
--- a/agents/ubuntu/ansible/roles/common/tasks/virt.yml
+++ b/agents/ubuntu/ansible/roles/common/tasks/virt.yml
@@ -3,6 +3,7 @@
     deb: https://releases.hashicorp.com/vagrant/2.2.19/vagrant_2.2.19_x86_64.deb
 
 - name: Cache Vagrant boxes used for package testing
+  become_user: buildkite-agent
   args:
     executable: /bin/bash
   shell: |


### PR DESCRIPTION
Vagrant boxes are installed per user.  This ensures we cache boxes on
the same account running tests.