### PR TITLE
Bump fpm to 1.14.2

### DIFF
--- a/agents/ubuntu/ansible/roles/common/tasks/misc.yml
+++ b/agents/ubuntu/ansible/roles/common/tasks/misc.yml
@@ -1,7 +1,7 @@
 - name: Install fpm
   community.general.gem:
     name: fpm
-    version: 1.13.1
+    version: 1.14.2
     state: present
     user_install: no
 


### PR DESCRIPTION
https://github.com/jordansissel/fpm/blob/main/CHANGELOG.rst

Doing maintenance on packages.  For us impact is minimal - uses pip, and fixes a deprecation warning.