### PR TITLE
Bump ecctl timeout

### DIFF
--- a/agents/ubuntu/ansible/roles/common/templates/ecctl.json
+++ b/agents/ubuntu/ansible/roles/common/templates/ecctl.json
@@ -2,5 +2,6 @@
   "host": "https://api.elastic-cloud.com",
   "region": "gcp-us-central1",
   "output": "json",
-  "insecure": true
+  "insecure": true,
+  "timeout": 300000000000
 }

--- a/agents/ubuntu/packer/ecctl.json
+++ b/agents/ubuntu/packer/ecctl.json
@@ -2,5 +2,6 @@
   "host": "https://api.elastic-cloud.com",
   "region": "gcp-us-central1",
   "output": "json",
-  "insecure": true
+  "insecure": true,
+  "timeout": 300000000000
 }


### PR DESCRIPTION
The default timeout is 30 seconds for http calls.  We've seen sporadic
failures where Cloud instances are initialized but the task errors, causing
vault write and build step failures.  This bumps the value to 5 minutes
(in nanonseconds).  This isn't a fix but should hopefully improve
stability.

No issues making this a less aggressive bump, I just added a 0.