### PR TITLE
Revert "Unpin chrome (#48)"

### DIFF
--- a/agents/ubuntu/ansible/roles/common/tasks/packages.yml
+++ b/agents/ubuntu/ansible/roles/common/tasks/packages.yml
@@ -160,7 +160,12 @@
       - qemu-system
       - libvirt-clients
       - libvirt-daemon-system
-      - google-chrome-stable
+      # - google-chrome-stable # TODO re-enable after Chrome 104 is released. 103 has bugs
       - firefox
     state: latest
+    install_recommends: no
+
+- name: Install Chrome 102
+  apt:
+    deb: http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_102.0.5005.115-1_amd64.deb
     install_recommends: no


### PR DESCRIPTION
This reverts commit 7ffb506441b8a1ea2c22bb7a479568ab1c50c114.

We're still seeing no-session errors (e.g. https://buildkite.com/elastic/kibana-on-merge/builds/19778).  I'm testing chrome 104 at https://github.com/elastic/kibana/pull/138658 with a selenium upgrade to see if that helps, otherwise the plan is to merge this before the next image build.